### PR TITLE
Add effects to RGB LED

### DIFF
--- a/esphome/esphome.yaml
+++ b/esphome/esphome.yaml
@@ -21,6 +21,9 @@ substitutions:
   # pir_delayed_off: 1s
   # pir_delayed_on: 0s
 
+  # led_strobe_on: 50ms   # controls the strobe effect if rgb_led or led is enabled
+  # led_strobe_off: 100ms 
+
 packages:
   remote_package:
     url: https://github.com/schluggi/AIOsense

--- a/esphome/esphome.yaml
+++ b/esphome/esphome.yaml
@@ -22,7 +22,7 @@ substitutions:
   # pir_delayed_on: 0s
 
   # led_strobe_on: 50ms   # controls the strobe effect if rgb_led or led is enabled
-  # led_strobe_off: 100ms 
+  # led_strobe_off: 100ms
 
 packages:
   remote_package:

--- a/esphome/packages/sensors/led.yaml
+++ b/esphome/packages/sensors/led.yaml
@@ -2,7 +2,7 @@ substitutions:
   led_invert: "false"
   led_strobe_on: 50ms
   led_strobe_off: 100ms
-  
+
 output:
   - id: led_output
     platform: gpio

--- a/esphome/packages/sensors/led.yaml
+++ b/esphome/packages/sensors/led.yaml
@@ -23,7 +23,6 @@ light:
               duration: "${led_strobe_on}"
             - state: false
               duration: "${led_strobe_off}"
-      - pulse:
 
 esphome:
   on_boot:

--- a/esphome/packages/sensors/led.yaml
+++ b/esphome/packages/sensors/led.yaml
@@ -1,7 +1,7 @@
 substitutions:
   led_invert: "false"
-  led_strobe_on: "50ms"
-  led_strobe_off": "100ms"
+  led_strobe_on: 50ms
+  led_strobe_off: 100ms
   
 output:
   - id: led_output

--- a/esphome/packages/sensors/led.yaml
+++ b/esphome/packages/sensors/led.yaml
@@ -1,6 +1,8 @@
 substitutions:
   led_invert: "false"
-
+  led_strobe_on: "50ms"
+  led_strobe_off": "100ms"
+  
 output:
   - id: led_output
     platform: gpio
@@ -14,6 +16,14 @@ light:
     name: "LED"
     output: led_output
     icon: "mdi:led-outline"
+    effects:
+      - strobe:
+          colors:
+            - state: true
+              duration: "${led_strobe_on}"
+            - state: false
+              duration: "${led_strobe_off}"
+      - pulse:
 
 esphome:
   on_boot:

--- a/esphome/packages/sensors/rgb_led.yaml
+++ b/esphome/packages/sensors/rgb_led.yaml
@@ -2,7 +2,7 @@
 substitutions:
   led_strobe_on: 50ms
   led_strobe_off: 100ms
-  
+
 light:
   - platform: neopixelbus
     name: "LED"
@@ -39,7 +39,7 @@ light:
             - state: false
               duration: "${led_strobe_off}"
       - pulse:
-      
+
 esphome:
   on_boot:
     then:

--- a/esphome/packages/sensors/rgb_led.yaml
+++ b/esphome/packages/sensors/rgb_led.yaml
@@ -12,15 +12,6 @@ light:
     num_leds: 1
     pin: "${rgb_led_pin}"
     icon: "mdi:led-outline"
-light:
-  - platform: neopixelbus
-    name: "LED"
-    id: led
-    type: GRB
-    variant: WS2812X
-    num_leds: 1
-    pin: "${rgb_led_pin}"
-    icon: "mdi:led-outline"
     effects:
       - strobe:
           colors:

--- a/esphome/packages/sensors/rgb_led.yaml
+++ b/esphome/packages/sensors/rgb_led.yaml
@@ -1,7 +1,7 @@
 # https://esphome.io/components/light/neopixelbus.html
 substitutions:
-  strobe_on: 50ms
-  strobe_off: 100ms
+  led_strobe_on: 50ms
+  led_strobe_off: 100ms
   
 light:
   - platform: neopixelbus
@@ -16,9 +16,9 @@ light:
       - strobe:
           colors:
             - state: true
-              duration: "${strobe_on}"
+              duration: "${led_strobe_on}"
             - state: false
-              duration: "${strobe_off}"
+              duration: "${led_strobe_off}"
       - strobe:
           name: Alarm
           colors:
@@ -27,17 +27,17 @@ light:
               red: 100%
               green: 0%
               blue: 0%
-              duration: "${strobe_on}"
+              duration: "${led_strobe_on}"
             - state: false
-              duration: "${strobe_off}"
+              duration: "${led_strobe_off}"
             - state: true
               brightness: 100%
               red: 100%
               green: 100%
               blue: 100%
-              duration: "${strobe_on}"
+              duration: "${led_strobe_on}"
             - state: false
-              duration: "${strobe_off}"
+              duration: "${led_strobe_off}"
       - pulse:
       
 esphome:

--- a/esphome/packages/sensors/rgb_led.yaml
+++ b/esphome/packages/sensors/rgb_led.yaml
@@ -1,4 +1,8 @@
 # https://esphome.io/components/light/neopixelbus.html
+substitutions:
+  strobe_on: 50ms
+  strobe_off: 100ms
+  
 light:
   - platform: neopixelbus
     name: "LED"
@@ -8,7 +12,43 @@ light:
     num_leds: 1
     pin: "${rgb_led_pin}"
     icon: "mdi:led-outline"
-
+light:
+  - platform: neopixelbus
+    name: "LED"
+    id: led
+    type: GRB
+    variant: WS2812X
+    num_leds: 1
+    pin: "${rgb_led_pin}"
+    icon: "mdi:led-outline"
+    effects:
+      - strobe:
+          colors:
+            - state: true
+              duration: "${strobe_on}"
+            - state: false
+              duration: "${strobe_off}"
+      - strobe:
+          name: Alarm
+          colors:
+            - state: true
+              brightness: 100%
+              red: 100%
+              green: 0%
+              blue: 0%
+              duration: "${strobe_on}"
+            - state: false
+              duration: "${strobe_off}"
+            - state: true
+              brightness: 100%
+              red: 100%
+              green: 100%
+              blue: 100%
+              duration: "${strobe_on}"
+            - state: false
+              duration: "${strobe_off}"
+      - pulse:
+      
 esphome:
   on_boot:
     then:


### PR DESCRIPTION
Home Alarm system is integrated with HA. This is a small addition to give AIOsense the ability to use a few LED effects and provide a visual indicator as these are placed in every room of the house. Also, made the strobing configurable since the default timings are a bit too calm for my preferences.