### PR TITLE
Add sps30 Particulate Matter Sensor

### DIFF
--- a/esphome/esphome.yaml
+++ b/esphome/esphome.yaml
@@ -26,8 +26,10 @@ substitutions:
 
 packages:
   remote_package:
-    url: https://github.com/schluggi/AIOsense
-    ref: esphome-v3.0.0
+    # url: https://github.com/schluggi/AIOsense
+    # ref: esphome-v3.0.0
+    url: https://github.com/tomvancutsem/AIOsense
+    ref: sps30
     refresh: 1d
     files:
       - esphome/packages/config/base.yaml

--- a/esphome/esphome.yaml
+++ b/esphome/esphome.yaml
@@ -46,6 +46,7 @@ packages:
       - esphome/packages/sensors/buzzer.yaml  # PCB >= v2.1.0
       - esphome/packages/sensors/occupancy.yaml  # only if pir & mmWave are activated
       - esphome/packages/sensors/pir.yaml
+      # - esphome/packages/sensors/sps30.yaml
 
       # ----- voice assistant (use rgb_led for esp32-c3 & esp32-s3 only-----
       - esphome/packages/sensors/voice_assistant-rgb_led.yaml

--- a/esphome/packages/config/esp32-s3-mini.yaml
+++ b/esphome/packages/config/esp32-s3-mini.yaml
@@ -1,12 +1,12 @@
 substitutions:
-  buzzer_pin: GPIO13
-  i2s_bclk_pin: GPIO12
-  i2s_din_pin: "${buzzer_pin}"
-  i2s_lrclk_pin: GPIO10
-  pir_pin: GPIO11
+  buzzer_pin: GPIO1
+  i2s_bclk_pin: GPIO38
+  i2s_din_pin: GPIO37
+  i2s_lrclk_pin: GPIO35
+  pir_pin: GPIO3
   rgb_led_pin: GPIO47
   rgb_led_type: RGB
-  sen0395_io_pin: GPIO4
+  sen0395_io_pin: GPIO33
   uart_rx_pin: GPIO44
   uart_tx_pin: GPIO43
 
@@ -18,8 +18,8 @@ esp32:
     version: latest
 
 i2c:
-  sda: GPIO35
-  scl: GPIO36
+  sda: GPIO21
+  scl: GPIO17
 
 sensor:
   - platform: internal_temperature

--- a/esphome/packages/config/esp32-s3-mini.yaml
+++ b/esphome/packages/config/esp32-s3-mini.yaml
@@ -2,6 +2,7 @@ substitutions:
   buzzer_pin: GPIO1
   i2s_bclk_pin: GPIO38
   i2s_din_pin: GPIO37
+  i2s_dout_pin: GPIO36
   i2s_lrclk_pin: GPIO35
   pir_pin: GPIO3
   rgb_led_pin: GPIO47

--- a/esphome/packages/sensors/occupancy.yaml
+++ b/esphome/packages/sensors/occupancy.yaml
@@ -2,6 +2,9 @@ switch:
   - platform: template
     name: "Occupancy on by pir only"
     id: occupancy_on_by_pir
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_OFF
+    entity_category: config
 
 binary_sensor:
   - platform: template

--- a/esphome/packages/sensors/occupancy.yaml
+++ b/esphome/packages/sensors/occupancy.yaml
@@ -1,10 +1,15 @@
+switch:
+  - platform: template
+    name: "Occupancy on by pir only"
+    id: occupancy_on_by_pir
+
 binary_sensor:
   - platform: template
     name: "Occupancy"
     id: occupancy
     device_class: occupancy
     lambda: |-
-      if (id(motion_mmwave).state or id(motion_pir).state) {
+      if ((id(motion_mmwave).state and id(occupancy_on_by_pir).state==0) or id(motion_pir).state) {
         return true;
       }
       else if (id(motion_mmwave).state == 0 and id(motion_pir).state == 0) {

--- a/esphome/packages/sensors/sps30.yaml
+++ b/esphome/packages/sensors/sps30.yaml
@@ -1,0 +1,27 @@
+# https://esphome.io/components/sensor/sps30.html
+
+
+sensor:
+  - platform: sps30
+    pm_1_0:
+      name: "PM1"
+      id: "pm1"
+      unit_of_measurement: "μg/m³"
+      accuracy_decimals: 0
+    pm_2_5:
+      name: "PM2.5"
+      id: "pm25"
+      unit_of_measurement: "μg/m³"
+      accuracy_decimals: 0
+    pm_4_0:
+      name: "PM4"
+      id: "pm4"
+      unit_of_measurement: "μg/m³"
+      accuracy_decimals: 0
+    pm_10_0:
+      name: "PM10"
+      id: "pm10"
+      unit_of_measurement: "μg/m³"
+      accuracy_decimals: 0
+    address: 0x69
+    update_interval: 10s

--- a/esphome/packages/sensors/sps30.yaml
+++ b/esphome/packages/sensors/sps30.yaml
@@ -6,22 +6,17 @@ sensor:
     pm_1_0:
       name: "PM1"
       id: "pm1"
-      unit_of_measurement: "μg/m³"
       accuracy_decimals: 0
+      device_class: PM1
     pm_2_5:
       name: "PM2.5"
       id: "pm25"
-      unit_of_measurement: "μg/m³"
       accuracy_decimals: 0
-    pm_4_0:
-      name: "PM4"
-      id: "pm4"
-      unit_of_measurement: "μg/m³"
-      accuracy_decimals: 0
+      device_class: PM25
     pm_10_0:
       name: "PM10"
       id: "pm10"
-      unit_of_measurement: "μg/m³"
       accuracy_decimals: 0
+      device_class: PM10
     address: 0x69
-    update_interval: 10s
+    update_interval: 60s

--- a/esphome/packages/sensors/voice_assistant-rgb_led.yaml
+++ b/esphome/packages/sensors/voice_assistant-rgb_led.yaml
@@ -1,7 +1,21 @@
 i2s_audio:
-  id: i2s_in
   i2s_lrclk_pin: "${i2s_lrclk_pin}"  # WS
   i2s_bclk_pin: "${i2s_bclk_pin}"  # SCK
+
+microphone:
+  - platform: i2s_audio
+    id: mic_i2s
+    channel: left
+    adc_type: external
+    i2s_din_pin: "${i2s_din_pin}"  # SD
+    pdm: false
+
+speaker:
+  - platform: i2s_audio
+    id: speaker_i2s
+    dac_type: external
+    i2s_dout_pin: ${i2s_dout_pin}
+    mode: mono
 
 microphone:
   - platform: i2s_audio
@@ -15,6 +29,7 @@ microphone:
 voice_assistant:
   id: va
   microphone: mic_i2s
+  speaker: speaker_i2s
   noise_suppression_level: 2
   auto_gain: 31dBFS
   volume_multiplier: 2.0


### PR DESCRIPTION
Add support for the sps30 Particulate Matter Sensor.

Case design in Onshape:
https://cad.onshape.com/documents/dce3c544d8f0f6d4aaece8e1/w/af2f3ba1b635d2ccd180d7ec/e/585a27617f725e5ec6a041fe?configuration=List_B4cEdGNdSGp3oh%3DDefault&renderMode=2&uiState=659aad8aa559c65033e25688

![20240107_135510686_iOS](https://github.com/Schluggi/AIOsense/assets/28868928/06dc0249-f1ae-4040-a3af-f4d429e98930)
![20240107_135518037_iOS](https://github.com/Schluggi/AIOsense/assets/28868928/c2704a2d-4cf3-4c16-960a-a08c2f9c5d77)
![20240107_141420940_iOS](https://github.com/Schluggi/AIOsense/assets/28868928/dbb10110-0c80-40ea-b8f6-d5c6293031ea)
![20240107_141549682_iOS](https://github.com/Schluggi/AIOsense/assets/28868928/652600c0-1efd-415c-ab8b-9fda0857ff1d)
