### PR TITLE
Create sps30.yaml

### DIFF
--- a/esphome/packages/sensors/sps30.yaml
+++ b/esphome/packages/sensors/sps30.yaml
@@ -1,0 +1,22 @@
+# https://esphome.io/components/sensor/sps30.html
+
+
+sensor:
+  - platform: sps30
+    pm_1_0:
+      name: "PM1"
+      id: "pm1"
+      accuracy_decimals: 0
+      device_class: PM1
+    pm_2_5:
+      name: "PM2.5"
+      id: "pm25"
+      accuracy_decimals: 0
+      device_class: PM25
+    pm_10_0:
+      name: "PM10"
+      id: "pm10"
+      accuracy_decimals: 0
+      device_class: PM10
+    address: 0x69
+    update_interval: 60s


### PR DESCRIPTION
Add support for the sps30 Particulate Matter Sensor.

Case design in Onshape:
https://cad.onshape.com/documents/dce3c544d8f0f6d4aaece8e1/w/af2f3ba1b635d2ccd180d7ec/e/585a27617f725e5ec6a041fe?configuration=List_B4cEdGNdSGp3oh%3DDefault&renderMode=2&uiState=659aad8aa559c65033e25688

Compared to the first pull request, I left out the sensors for 4um and set the update_interval to 60s.


![20240107_135510686_iOS](https://github.com/Schluggi/AIOsense/assets/28868928/a1347b08-c8e6-4f36-80c8-ef4aec07da14)
![20240107_135518037_iOS](https://github.com/Schluggi/AIOsense/assets/28868928/10bb26f2-0921-4c9e-9257-183ef8192f75)
![20240107_141420940_iOS](https://github.com/Schluggi/AIOsense/assets/28868928/d200c860-73f6-4bc4-b7a1-7dff07dcddd0)
![20240107_141549682_iOS](https://github.com/Schluggi/AIOsense/assets/28868928/986d6277-c7f7-43cf-b6c9-e0953cd2879f)
