### PR TITLE
OTABackend separation due to PR 6459 in esphome

### DIFF
--- a/esphome/esphome.yaml
+++ b/esphome/esphome.yaml
@@ -66,7 +66,8 @@ api:
     key: "<secret>"
 
 ota:
-  password: "<secret>"
+  - platform: esphome
+    password: "<secret>"
 
 wifi:
   ssid: !secret wifi_ssid


### PR DESCRIPTION
See https://github.com/esphome/esphome/pull/6459

Without this change AIOsense installation/update will fail with 

'ota' requires a 'platform' key but it was not specified.